### PR TITLE
Bug // Mensa Modul // Die HTWK-App stürzt beim Aufruf der Mensa am Park ab

### DIFF
--- a/packages/components/MensaMenu/index.js
+++ b/packages/components/MensaMenu/index.js
@@ -182,7 +182,11 @@ function Meal({ settings, meal, priceGroupCode, priceGroupName }) {
                     </Text>
                     <Text>
                         <SelectionIcons
-                            selections={meal?.selections ?? []}
+                            selections={
+                                Arrays.isArray(meal?.selections)
+                                    ? meal.selections
+                                    : []
+                            }
                             iconSize={styles.mealItemTitleText.lineHeight}
                         />
                     </Text>


### PR DESCRIPTION
Behebt das [Gitlab-Ticket 731](https://gitlab.hrz.tu-chemnitz.de/OpenASiST/openasist/-/issues/731) .

Es wird geprüft, ob im `selection`-Feld der Essen ein Array enthalten ist, wenn nicht, werden keine Selections angezeigt. 