### PR TITLE
Bump @olea-bps/context-event to version 1.0.4

### DIFF
--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -23,7 +23,7 @@
     "@olea-bps/context-canteen": "^1.0.0",
     "@olea-bps/context-user": "^1.0.0",
     "@olea-bps/context-public-transport-ticket": "^1.0.0",
-    "@olea-bps/context-event": "^1.0.0",
+    "@olea-bps/context-event": "^1.0.4",
     "@olea-bps/context-info-dialog": "^1.0.0",
     "@olea-bps/context-callmanager": "^1.0.0",
     "@olea-bps/context-news": "^1.0.0",


### PR DESCRIPTION
This pull request updates the dependency version for `@olea-bps/context-event` in the `packages/views/package.json` file to ensure the project uses the latest compatible release.

* Dependency update:
  * Upgraded `@olea-bps/context-event` from version `^1.0.0` to `^1.0.4` in `packages/views/package.json` to pull in recent fixes or features.