### PR TITLE
Develop - Master

### DIFF
--- a/packages/components/TimetableDay/index.js
+++ b/packages/components/TimetableDay/index.js
@@ -39,7 +39,7 @@ const daysTabDuration = Duration.fromISO('P6M');
  * @param {(DateTime) => void} props.onDateChanged Callback, welche aufgerufen wird, wenn der Tag in der Ansicht wechselt
  * @returns
  */
-function CalendarDay({ selectedDate, theme, settings, calendarScrollOffsetMinutes, onDateChanged, onCourseSelected }) {
+function CalendarDay({ selectedDate, theme, settings, calendarScrollOffsetMinutes, calendarHeight, onDateChanged, onCourseSelected }) {
     const { appSettings: { modules: { timetable: { showDetails } } } } = theme;
     const today = DateTime.now().toISODate();
 
@@ -169,7 +169,7 @@ function CalendarDay({ selectedDate, theme, settings, calendarScrollOffsetMinute
                         renderHeader={() => null}
                         overlapOffset={95}
                         mode={'day'}
-                        height={800}
+                        height={calendarHeight}
                         headerContentStyle={{ backgroundColor: 'transparent' }}
                         weekStartsOn={1}
                         date={route.key}

--- a/packages/components/TimetableMonth/index.js
+++ b/packages/components/TimetableMonth/index.js
@@ -26,7 +26,7 @@ import CalendarStrip from 'react-native-calendar-strip';
 import { DateTime } from 'luxon';
 
 function CalendarMonth(props) {
-  const { theme, setMonth, today, locale, onMonthChanged } = props;
+  const { theme, setMonth, today, locale, onMonthChanged, calendarHeight } = props;
   const styles = useMemo(
     () => StyleSheet.create(componentStyles(theme)),
     [theme]
@@ -121,7 +121,7 @@ function CalendarMonth(props) {
         renderEvent={renderEvent}
         renderHeaderForMonthView={renderHeader}
         date={selectedDate.current}
-        height={800}
+        height={calendarHeight}
         mode={'month'}
         headerContentStyle={{ backgroundColor: 'transparent' }}
         weekStartsOn={1}

--- a/packages/components/TimetableWeek/index.js
+++ b/packages/components/TimetableWeek/index.js
@@ -40,7 +40,7 @@ const daysTabDuration = Duration.fromISO('P6M');
  * @returns
  */
 function CalendarWeek(props) {
-  const { selectedISOWeek, theme, settings, calendarScrollOffsetMinutes, onWeekChanged, onCourseSelected } = props;
+  const { selectedISOWeek, theme, settings, calendarScrollOffsetMinutes, calendarHeight, onWeekChanged, onCourseSelected } = props;
 
   const styles = useMemo(
     () => StyleSheet.create(componentStyles(theme)),
@@ -167,7 +167,7 @@ function CalendarWeek(props) {
             renderEvent={renderEvent}
             renderHeader={() => null}
             mode={'week'}
-            height={800}
+            height={calendarHeight}
             headerContentStyle={{ backgroundColor: 'transparent' }}
             weekStartsOn={1}
             date={route.weekbeginISODate}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olea-bps/components",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Consolidated components for OLEA",
   "main": "index.js",
   "repository": "https://github.com/tuc-urz/olea.git",

--- a/packages/views/TimetableCalendar/index.js
+++ b/packages/views/TimetableCalendar/index.js
@@ -59,6 +59,26 @@ function TimetableViewCalendar(props) {
   const [errorMessage, setErrorMessage] = useState('');
   const [infoMessage, setInfoMessage] = useState('');
 
+  /**
+   * Höhe des Kalenders in Pixeln.
+   * Wird an die Calendar-Komponente in TimetableDay/TimetableWeek übergeben.
+   * WICHTIG: Bei Änderung dieses Wertes muss auch die height-Prop in TimetableDay und TimetableWeek angepasst werden!
+   */
+  const CALENDAR_HEIGHT = 800;
+
+  /**
+   * Interne Mindesthöhe der react-native-big-calendar Bibliothek.
+   * Siehe: node_modules/react-native-big-calendar/build/index.es.js (MIN_HEIGHT = 1200)
+   */
+  const CALENDAR_MIN_HEIGHT = 1200;
+
+  /**
+   * Berechnet die Höhe einer Stunden-Zelle in Pixeln.
+   * Verwendet die gleiche Formel wie react-native-big-calendar intern:
+   * cellHeight = Math.max(height - 30, MIN_HEIGHT) / 24
+   */
+  const calculateCellHeight = (height) => Math.max(height - 30, CALENDAR_MIN_HEIGHT) / 24;
+
   // Berechnen der Uhrzeit zu der beim Öffnen des Stundenplan Kalenders hingepsrungen werden soll.
   // Wird in einem State gespeichert, weil später noch beim Focus-Wechsel erneut berechnet werden muss.
   const [calendarScrollOffsetMinutes, setCalendarScrollOffsetMinutes] = useState(
@@ -70,7 +90,25 @@ function TimetableViewCalendar(props) {
         : Duration.fromObject({ hours: DateTime.now().hour });
 
       // Duration wird in Minuten umgewandelt, weil der Kalender ein Minutenoffset erwartet
-      return calendarScrollOffsetDuration.as('minutes');
+      const offsetMinutes = calendarScrollOffsetDuration.as('minutes');
+
+      /**
+       * iOS Workaround für Bug in react-native-big-calendar (v4.0.19)
+       *
+       * Problem: Die Bibliothek behandelt scrollOffsetMinutes auf iOS falsch.
+       * - Android verwendet: scrollTo({ y: (cellHeight * scrollOffsetMinutes) / 60 })
+       * - iOS verwendet: contentOffset.y = scrollOffsetMinutes (direkt als Pixel!)
+       *
+       * Lösung: Auf iOS den Wert vorab in Pixel umrechnen mit der gleichen Formel wie Android.
+       *
+       * Siehe: node_modules/react-native-big-calendar/build/index.es.js (Zeile 799 und 895)
+       */
+      if (Platform.OS === 'ios') {
+        const cellHeight = calculateCellHeight(CALENDAR_HEIGHT);
+        return (cellHeight * offsetMinutes) / 60;
+      }
+
+      return offsetMinutes;
     }
   );
 
@@ -105,6 +143,7 @@ function TimetableViewCalendar(props) {
         return <CalendarDay
           selectedDate={selectedDayModeDate}
           calendarScrollOffsetMinutes={calendarScrollOffsetMinutes}
+          calendarHeight={CALENDAR_HEIGHT}
           onDateChanged={setSelectedDayModeDate}
           onCourseSelected={setSelectedEvent}
         />;
@@ -112,11 +151,12 @@ function TimetableViewCalendar(props) {
         return <CalendarWeek
           selectedISOWeek={selectedWeekModeISOWeekDate}
           calendarScrollOffsetMinutes={calendarScrollOffsetMinutes}
+          calendarHeight={CALENDAR_HEIGHT}
           onWeekChanged={setSelectedWeekModeISOWeekDate}
           onCourseSelected={setSelectedEvent}
         />;
       case 'month':
-        return <CalendarMonth today={today} setToday={setToday} month={month} setMonth={setMonth} calendarScrollOffsetMinutes={calendarScrollOffsetMinutes} />;
+        return <CalendarMonth today={today} setToday={setToday} month={month} setMonth={setMonth} calendarScrollOffsetMinutes={calendarScrollOffsetMinutes} calendarHeight={CALENDAR_HEIGHT} />;
       default:
         return null;
     }

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olea-bps/views",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Consolidated views for OLEA",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This pull request improves the flexibility and reliability of the timetable calendar views by introducing a configurable calendar height across day, week, and month views, and by adding a platform-specific workaround for iOS scrolling behavior. The changes also include minor version bumps for the affected packages.

**Calendar height configuration and usage:**
* Added a `calendarHeight` prop to `CalendarDay`, `CalendarWeek`, and `CalendarMonth` components, replacing the previously hardcoded height value of 800 with a configurable constant (`CALENDAR_HEIGHT`). This allows for easier adjustments and consistency across views. [[1]](diffhunk://#diff-9cc3e1db6698aba3db6b79be2c8b416706a73368a98051cb99667e97325d39baR62-R81) [[2]](diffhunk://#diff-9cc3e1db6698aba3db6b79be2c8b416706a73368a98051cb99667e97325d39baR146-R159) [[3]](diffhunk://#diff-1fe510cad0a42e797721b953cd97689860704a8734349823da4af14de73aa33dL42-R42) [[4]](diffhunk://#diff-1fe510cad0a42e797721b953cd97689860704a8734349823da4af14de73aa33dL172-R172) [[5]](diffhunk://#diff-19c088a47fd0f382ed438dc17dbf7f3eb2655cf837f3cce9d386e3a01d8fbdd9L43-R43) [[6]](diffhunk://#diff-19c088a47fd0f382ed438dc17dbf7f3eb2655cf837f3cce9d386e3a01d8fbdd9L170-R170) [[7]](diffhunk://#diff-527c170f4b078b8bf33a88284e55c09f0ea2cbcf2db0bfe6c9667d79a571998bL29-R29) [[8]](diffhunk://#diff-527c170f4b078b8bf33a88284e55c09f0ea2cbcf2db0bfe6c9667d79a571998bL124-R124)

**Platform-specific bug workaround:**
* Implemented an iOS-specific workaround for a known bug in the `react-native-big-calendar` library, ensuring that the calendar scroll offset is correctly calculated in pixels for iOS devices. This improves the scrolling experience and consistency between platforms.

**Version updates:**
* Bumped the version of `@olea-bps/components` to `1.0.11` and `@olea-bps/views` to `1.0.8` to reflect the new features and fixes. [[1]](diffhunk://#diff-2c76dc06185f93bec73660e15338433b95eac6707317564c0f778f5b9abe446cL3-R3) [[2]](diffhunk://#diff-e996d92cad999950f184e662033f1bdf4f790084ad480ba5118a5ef11ef7e19cL3-R3)