### PR TITLE
Rename @olea scope back to @olea-bps for npm compatibility

### DIFF
--- a/apps/app-olea/App.js
+++ b/apps/app-olea/App.js
@@ -9,7 +9,7 @@ import { I18nextProvider } from 'react-i18next';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Provider as ReduxProvider } from 'react-redux'
 
-import { store, onSettingAPI } from '@olea/base';
+import { store, onSettingAPI } from '@olea-bps/base';
 
 import settings from './constants/Settings';
 import i18n from './i18n/i18n';

--- a/apps/app-olea/Main.js
+++ b/apps/app-olea/Main.js
@@ -4,16 +4,16 @@ import { Alert, AppState, Linking, StatusBar } from 'react-native';
 import { connect } from 'react-redux'
 import { Provider as PaperProvider } from 'react-native-paper';
 import { NavigationContainer } from "@react-navigation/native";
-import { DataService, RootNavigation, store } from '@olea/base';
+import { DataService, RootNavigation, store } from '@olea-bps/base';
 
 import i18n from './i18n/i18n';
 import { getTheme } from './constants/Theme';
 import MainTabNavigator from './navigation/MainTabNavigator';
 
-import { CanteenContextProvider } from '@olea/base'
-import { TimetableContextProvider } from '@olea/base';
-import { ConnectivityContextProvider } from '@olea/base';
-import { NewsContextProvider } from '@olea/base';
+import { CanteenContextProvider } from '@olea-bps/base'
+import { TimetableContextProvider } from '@olea-bps/base';
+import { ConnectivityContextProvider } from '@olea-bps/base';
+import { NewsContextProvider } from '@olea-bps/base';
 
 import settings from './constants/Settings';
 import { withTranslation } from 'react-i18next';

--- a/apps/app-olea/i18n/i18n.js
+++ b/apps/app-olea/i18n/i18n.js
@@ -5,7 +5,7 @@ import localeEN from './locales/en';
 import localeDE from './locales/de';
 import localeDEAccessibility from './locales/de-accessibility';
 import localeENAccessibility from './locales/en-accessibility';
-import { store } from '@olea/base';
+import { store } from '@olea-bps/base';
 
 const resources = {
     en: {...localeEN, ...localeENAccessibility},

--- a/apps/app-olea/navigation/MainTabNavigator.js
+++ b/apps/app-olea/navigation/MainTabNavigator.js
@@ -2,7 +2,7 @@ import { View }                                from 'react-native';
 import { useTranslation }                      from 'react-i18next';
 import { createBottomTabNavigator }            from '@react-navigation/bottom-tabs';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ConnectivityWarning }                 from '@olea/base';
+import { ConnectivityWarning }                 from '@olea-bps/base';
 
 import DashboardStack                          from './stacks/dashboard';
 import FeedsStack                              from './stacks/feeds';

--- a/apps/app-olea/navigation/stacks/canteens.js
+++ b/apps/app-olea/navigation/stacks/canteens.js
@@ -1,10 +1,10 @@
 import React                    from 'react';
 import { createStackNavigator } from "@react-navigation/stack";
 
-import { Canteens as CanteensTabView } from '@olea/base';
+import { Canteens as CanteensTabView } from '@olea-bps/base';
 
 
-import { Modal as ModalComponent } from '@olea/base';
+import { Modal as ModalComponent } from '@olea-bps/base';
 
 import TabBarIcon               from "../tabBarIcon";
 

--- a/apps/app-olea/navigation/stacks/dashboard.js
+++ b/apps/app-olea/navigation/stacks/dashboard.js
@@ -1,10 +1,10 @@
 import React                    from 'react';
 import { createStackNavigator } from "@react-navigation/stack";
 
-import { DashboardHtwk as DashboardView } from '@olea/base';
-import { NewsDetail as NewsDetailComponent } from '@olea/base';
-import { CourseDetail as CourseDetailComponent } from '@olea/base';
-import { Modal as ModalComponent } from '@olea/base';
+import { DashboardHtwk as DashboardView } from '@olea-bps/base';
+import { NewsDetail as NewsDetailComponent } from '@olea-bps/base';
+import { CourseDetail as CourseDetailComponent } from '@olea-bps/base';
+import { Modal as ModalComponent } from '@olea-bps/base';
 
 import TabBarIcon               from "../tabBarIcon";
 

--- a/apps/app-olea/navigation/stacks/feeds.js
+++ b/apps/app-olea/navigation/stacks/feeds.js
@@ -1,10 +1,10 @@
 import React                    from 'react';
 import { createStackNavigator } from "@react-navigation/stack";
 
-import { NewsDetail as NewsDetailComponent } from '@olea/base';
-import { NewsTabbar as NewsTabBarView } from '@olea/base';
-import { NewsList } from '@olea/base';
-import { Modal as ModalComponent } from '@olea/base';
+import { NewsDetail as NewsDetailComponent } from '@olea-bps/base';
+import { NewsTabbar as NewsTabBarView } from '@olea-bps/base';
+import { NewsList } from '@olea-bps/base';
+import { Modal as ModalComponent } from '@olea-bps/base';
 
 import TabBarIcon               from "../tabBarIcon";
 

--- a/apps/app-olea/navigation/stacks/menu.js
+++ b/apps/app-olea/navigation/stacks/menu.js
@@ -1,20 +1,20 @@
 import React                    from 'react';
 import { createStackNavigator, CardStyleInterpolators } from "@react-navigation/stack";
 
-import { MainMenu as MainMenuView } from '@olea/base';
-import { Opal as OpalView } from '@olea/base';
-import { SettingsGeneral as GeneralSettingsView } from '@olea/base';
-import { SettingsCanteens as CanteensSettingsView } from '@olea/base';
-import { SettingsAccessibility as AccessibilitySettingsView } from '@olea/base';
-import { Search as SearchView } from '@olea/base';
-import { Webviews as WebviewsView } from '@olea/base';
-import { Modal as ModalComponent } from '@olea/base';
-import { CourseDetail as CourseDetailComponent } from '@olea/base';
-import { Jobs as JobPortalView } from '@olea/base';
-import { ComponentJobsFilter as JobFilterComponent } from '@olea/base';
+import { MainMenu as MainMenuView } from '@olea-bps/base';
+import { Opal as OpalView } from '@olea-bps/base';
+import { SettingsGeneral as GeneralSettingsView } from '@olea-bps/base';
+import { SettingsCanteens as CanteensSettingsView } from '@olea-bps/base';
+import { SettingsAccessibility as AccessibilitySettingsView } from '@olea-bps/base';
+import { Search as SearchView } from '@olea-bps/base';
+import { Webviews as WebviewsView } from '@olea-bps/base';
+import { Modal as ModalComponent } from '@olea-bps/base';
+import { CourseDetail as CourseDetailComponent } from '@olea-bps/base';
+import { Jobs as JobPortalView } from '@olea-bps/base';
+import { ComponentJobsFilter as JobFilterComponent } from '@olea-bps/base';
 import TabBarIcon from '../tabBarIcon';
-import { SettingsAppInfo as AppInfoSettingsView } from '@olea/base';
-import { TimetableCalendar as TimetableCalendarView } from '@olea/base';
+import { SettingsAppInfo as AppInfoSettingsView } from '@olea-bps/base';
+import { TimetableCalendar as TimetableCalendarView } from '@olea-bps/base';
 
 /**
  * Tab Options

--- a/apps/app-olea/navigation/stacks/search.js
+++ b/apps/app-olea/navigation/stacks/search.js
@@ -1,8 +1,8 @@
 import React                    from 'react';
 import { createStackNavigator } from "@react-navigation/stack";
 
-import { Search as SearchView } from '@olea/base';
-import { Modal as ModalComponent } from '@olea/base';
+import { Search as SearchView } from '@olea-bps/base';
+import { Modal as ModalComponent } from '@olea-bps/base';
 
 import TabBarIcon               from "../tabBarIcon";
 

--- a/apps/app-olea/navigation/stacks/timetable-calendar.js
+++ b/apps/app-olea/navigation/stacks/timetable-calendar.js
@@ -1,6 +1,6 @@
 import { createStackNavigator } from '@react-navigation/stack';
 
-import { TimetableCalendar as TimetableViewCalendar } from '@olea/base';
+import { TimetableCalendar as TimetableViewCalendar } from '@olea-bps/base';
 
 import TabBarIcon from               '../tabBarIcon';
 

--- a/apps/app-olea/navigation/stacks/timetable-list.js
+++ b/apps/app-olea/navigation/stacks/timetable-list.js
@@ -1,8 +1,8 @@
 import { createStackNavigator } from '@react-navigation/stack';
 
-import { TimetableListView as TimetableViewList } from '@olea/base';
-import { CourseDetail as TimetableCourseView } from '@olea/base';
-import { Modal as ModalComponent } from '@olea/base';
+import { TimetableListView as TimetableViewList } from '@olea-bps/base';
+import { CourseDetail as TimetableCourseView } from '@olea-bps/base';
+import { Modal as ModalComponent } from '@olea-bps/base';
 
 import TabBarIcon               from '../tabBarIcon';
 

--- a/apps/app-olea/navigation/tabBarIcon.js
+++ b/apps/app-olea/navigation/tabBarIcon.js
@@ -1,7 +1,7 @@
 import React                    from 'react';
 import { View }                 from "react-native";
 
-import { IconsOpenasist }       from '@olea/base';
+import { IconsOpenasist }       from '@olea-bps/base';
 
 /**
  * Create a tab bar icon

--- a/apps/app-olea/package.json
+++ b/apps/app-olea/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@olea/app-oa",
+  "name": "@olea-bps/app-oa",
   "version": "1.0.0",
   "main": "./index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.1",
     "@notifee/react-native": "^9.1.8",
-    "@olea/base": "^1.0.0",
+    "@olea-bps/base": "^1.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-masked-view/masked-view": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@olea/container",
+  "name": "@olea-bps/container",
   "version": "",
   "private": true,
   "author": "codeculture<info@codeculture.de>",

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@olea/base",
+  "name": "@olea-bps/base",
   "version": "1.0.0",
   "description": "OLEA base library",
   "main": "index.js",


### PR DESCRIPTION
Renames all `@olea/` scoped packages back to `@olea-bps/` so they can be published to the existing npm organization.

- `@olea/base` → `@olea-bps/base`
- `@olea/app-oa` → `@olea-bps/app-oa`
- `@olea/container` → `@olea-bps/container`
- Updated 40 import statements across 12 JS files