### PR TITLE
Export Info-Dialog-Context

### DIFF
--- a/packages/index.js
+++ b/packages/index.js
@@ -156,6 +156,12 @@ export {
     useLogoutEffect,
 } from './context/context-user';
 
+export {
+    default as InfoContextProvider,
+    useInfoContext,
+    usePendingInfos,
+} from './context/context-info-dialog';
+
 // Exports Contexts libraries
 
 export {


### PR DESCRIPTION
Es wird der Context-Provider und die Hooks vom Info-Dialog-Context exportiert, damit diese in der TU Chemnitz-App verwendet werden kann.