### PR TITLE
Fix // ÖPNV-Ticket // Nutzen des Bildes vom Kollektor

### DIFF
--- a/apps/app-olea/package.json
+++ b/apps/app-olea/package.json
@@ -48,7 +48,6 @@
     "react-native-markdown-display": "^7.0.2",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.14.5",
-    "react-native-qrcode-svg": "^6.3.15",
     "react-native-safe-area-context": "~5.6.1",
     "react-native-screens": "~4.17.1",
     "react-native-tab-view": "^4.1.3",

--- a/packages/context/context-public-transport-ticket/index.js
+++ b/packages/context/context-public-transport-ticket/index.js
@@ -24,7 +24,7 @@ import CollektorVersion2ApiProvider from './CollektorVersion2ApiProvider';
 
 /**
  * @typedef Ticket
- * @property {string} barcode
+ * @property {string} barcode URL oder Data-URI für den Ticketbarcode als Bild
  * @property {string} owner
  * @property {date} valid_from
  * @property {date} valid_to
@@ -32,7 +32,7 @@ import CollektorVersion2ApiProvider from './CollektorVersion2ApiProvider';
 
 /**
  * @typedef PublicTransportTicketContext
- * @property {string} ticketBarcode
+ * @property {string} ticketBarcode Barcode Data-URI/URL
  * @property {string} ticketOwner
  * @property {string} ticketValidFrom
  * @property {string} ticketValidTo

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olea-bps/base",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OLEA base library",
   "main": "index.js",
   "repository": {

--- a/packages/views/PublicTransportTicket/index.js
+++ b/packages/views/PublicTransportTicket/index.js
@@ -13,7 +13,17 @@
  */
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { AppState, SafeAreaView, View, ScrollView, StyleSheet, Alert, useWindowDimensions, RefreshControl } from 'react-native';
+import {
+    AppState,
+    SafeAreaView,
+    View,
+    ScrollView,
+    StyleSheet,
+    Alert,
+    useWindowDimensions,
+    RefreshControl,
+    Image,
+} from 'react-native';
 
 import { useTheme, Text, Button } from 'react-native-paper';
 import { useFocusEffect } from '@react-navigation/native';
@@ -114,9 +124,8 @@ export default function PublicTransportTicketView() {
                                 ticketBarcode
                                     ? <>
                                         <View>
-                                            <QRCode
-                                                value={ticketBarcode}
-                                                size={width * 0.8}
+                                            <Image
+                                                source={{ uri: ticketBarcode }}
                                             />
                                         </View>
                                         <Text>

--- a/packages/views/PublicTransportTicket/index.js
+++ b/packages/views/PublicTransportTicket/index.js
@@ -28,7 +28,6 @@ import {
 import { useTheme, Text, Button } from 'react-native-paper';
 import { useFocusEffect } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
-import QRCode from 'react-native-qrcode-svg';
 
 import AppbarComponent from '../../components/AppBar';
 import { useUser } from '../../context/context-user';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,7 +2315,7 @@ __metadata:
     "@babel/core": "npm:^7.28.4"
     "@babel/runtime": "npm:^7.27.1"
     "@notifee/react-native": "npm:^9.1.8"
-    "@olea-bps/base": "npm:^1.0.0"
+    "@olea-bps/base": "npm:^1.0.2"
     "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-community/netinfo": "npm:^11.4.1"
     "@react-native-masked-view/masked-view": "npm:0.3.2"
@@ -2327,11 +2327,11 @@ __metadata:
     accordion-collapse-react-native: "npm:^1.1.1"
     dayjs: "npm:^1.11.18"
     expo: "npm:~54.0.32"
-    expo-application: "npm:~7.0.7"
+    expo-application: "npm:~7.0.8"
     expo-asset: "npm:~12.0.9"
-    expo-auth-session: "npm:~7.0.8"
+    expo-auth-session: "npm:~7.0.11"
     expo-build-properties: "npm:~1.0.9"
-    expo-crypto: "npm:~15.0.7"
+    expo-crypto: "npm:~15.0.9"
     expo-dev-client: "npm:~6.0.15"
     expo-device: "npm:~8.0.9"
     expo-font: "npm:~14.0.9"
@@ -2355,7 +2355,6 @@ __metadata:
     react-native-markdown-display: "npm:^7.0.2"
     react-native-pager-view: "npm:6.9.1"
     react-native-paper: "npm:^5.14.5"
-    react-native-qrcode-svg: "npm:^6.3.15"
     react-native-safe-area-context: "npm:~5.6.1"
     react-native-screens: "npm:~4.17.1"
     react-native-tab-view: "npm:^4.1.3"
@@ -2365,7 +2364,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@olea-bps/base@npm:^1.0.0, @olea-bps/base@workspace:packages":
+"@olea-bps/base@npm:^1.0.2, @olea-bps/base@workspace:packages":
   version: 0.0.0-use.local
   resolution: "@olea-bps/base@workspace:packages"
   dependencies:
@@ -2378,9 +2377,9 @@ __metadata:
     "@react-native-firebase/messaging": "npm:^22.2.0"
     "@react-navigation/drawer": "npm:^7.3.12"
     "@react-navigation/native": "npm:^7.1.9"
-    expo-application: "npm:~7.0.7"
-    expo-auth-session: "npm:~7.0.8"
-    expo-crypto: "npm:~15.0.7"
+    expo-application: "npm:~7.0.8"
+    expo-auth-session: "npm:~7.0.11"
+    expo-crypto: "npm:~15.0.9"
     expo-linear-gradient: "npm:~15.0.7"
     expo-web-browser: "npm:~15.0.10"
     jwt-decode: "npm:4.0.0"
@@ -3676,7 +3675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^5.0.0, camelcase@npm:^5.3.1":
+"camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: 10c0/92ff9b443bfe8abb15f2b1513ca182d16126359ad4f955ebc83dc4ddcc4ef3fdd2c078bc223f2673dc223488e75c99b16cc4d056624374b799e6a1555cf61b23
@@ -3794,17 +3793,6 @@ __metadata:
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "cliui@npm:6.0.0"
-  dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.0"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 10c0/35229b1bb48647e882104cac374c9a18e34bbf0bace0e2cf03000326b6ca3050d6b59545d91e17bfe3705f4a0e2988787aa5cde6331bf5cbbf0164732cef6492
   languageName: node
   linkType: hard
 
@@ -4123,13 +4111,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "decamelize@npm:1.2.0"
-  checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
-  languageName: node
-  linkType: hard
-
 "decode-uri-component@npm:^0.2.2":
   version: 0.2.2
   resolution: "decode-uri-component@npm:0.2.2"
@@ -4192,13 +4173,6 @@ __metadata:
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
-  languageName: node
-  linkType: hard
-
-"dijkstrajs@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "dijkstrajs@npm:1.0.3"
-  checksum: 10c0/2183d61ac1f25062f3c3773f3ea8d9f45ba164a00e77e07faf8cc5750da966222d1e2ce6299c875a80f969190c71a0973042192c5624d5223e4ed196ff584c99
   languageName: node
   linkType: hard
 
@@ -4403,7 +4377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-application@npm:~7.0.7, expo-application@npm:~7.0.8":
+"expo-application@npm:~7.0.8":
   version: 7.0.8
   resolution: "expo-application@npm:7.0.8"
   peerDependencies:
@@ -4426,20 +4400,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-auth-session@npm:~7.0.8":
-  version: 7.0.10
-  resolution: "expo-auth-session@npm:7.0.10"
+"expo-auth-session@npm:~7.0.11":
+  version: 7.0.11
+  resolution: "expo-auth-session@npm:7.0.11"
   dependencies:
     expo-application: "npm:~7.0.8"
-    expo-constants: "npm:~18.0.11"
-    expo-crypto: "npm:~15.0.8"
-    expo-linking: "npm:~8.0.10"
-    expo-web-browser: "npm:~15.0.10"
+    expo-constants: "npm:~18.0.13"
+    expo-crypto: "npm:~15.0.9"
+    expo-linking: "npm:~8.0.12"
+    expo-web-browser: "npm:~15.0.11"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/c29cd639eb9be3b408b3f6beffbb82e008a0ad1933be4f76155922fe73fc8ef618f015154b36193b0c2c0a05c488dcc0a5cc9a02121b8bf4bcb927e68cc105d0
+  checksum: 10c0/187755b5ee613b6aac3936ecbc3e7cad27b5e987d74feca37d651394b1db8138f3918900fea4c6798ddb3183a4443b471ed75cebcccf34bfcede94ec7c16feb1
   languageName: node
   linkType: hard
 
@@ -4455,7 +4429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-constants@npm:~18.0.11, expo-constants@npm:~18.0.12, expo-constants@npm:~18.0.13":
+"expo-constants@npm:~18.0.12, expo-constants@npm:~18.0.13":
   version: 18.0.13
   resolution: "expo-constants@npm:18.0.13"
   dependencies:
@@ -4468,14 +4442,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-crypto@npm:~15.0.7, expo-crypto@npm:~15.0.8":
-  version: 15.0.8
-  resolution: "expo-crypto@npm:15.0.8"
+"expo-crypto@npm:~15.0.9":
+  version: 15.0.9
+  resolution: "expo-crypto@npm:15.0.9"
   dependencies:
     base64-js: "npm:^1.3.0"
   peerDependencies:
     expo: "*"
-  checksum: 10c0/714806a2245a0aa05b7ec0d7044cd6ec317f3da7d96298b3a4b39c3ef8f62f25fa0d64b5b9df4018151a6b65c4c4348f6a7f5ad23e09bd73364daab260745df5
+  checksum: 10c0/fc0646231a57a4b58554734ead9be0a3bd2829900888926e8af94355fcf06632b846507553534ab8a04b52d268ec5bdb49100002105f91c1aae033384dfc56bc
   languageName: node
   linkType: hard
 
@@ -4589,16 +4563,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-linking@npm:~8.0.10":
-  version: 8.0.11
-  resolution: "expo-linking@npm:8.0.11"
+"expo-linking@npm:~8.0.12":
+  version: 8.0.12
+  resolution: "expo-linking@npm:8.0.12"
   dependencies:
-    expo-constants: "npm:~18.0.12"
+    expo-constants: "npm:~18.0.13"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/f4351bfd0a2cf1c0b2b3aa46e4484ee3f344f569d2dba7be31b914dc6274fc356dff413b3ab34bb9d36b205454a2e585b69abe54715e7f13e9629836c295c8d6
+  checksum: 10c0/56894fc1b53f3e21c197b547615395a2aec75535128db231abcce6356e5c28a3eaeca130816ee77c9bb74fa8f2ac01c996b4219d6bb0641d74bc9eb6eb1fe3e1
   languageName: node
   linkType: hard
 
@@ -4708,6 +4682,16 @@ __metadata:
     expo: "*"
     react-native: "*"
   checksum: 10c0/da56e5753aced5ee90260094b249dd0d8b7be1a973fd9b7e0b8d06e044888043534ce295ad072b67ca3698fc76c90329e445462c957b8d340eb83295ef9b22be
+  languageName: node
+  linkType: hard
+
+"expo-web-browser@npm:~15.0.11":
+  version: 15.0.11
+  resolution: "expo-web-browser@npm:15.0.11"
+  peerDependencies:
+    expo: "*"
+    react-native: "*"
+  checksum: 10c0/4dd8526979c5c7a987362989451272feb81289f56393f0ac5024c3e220c32edd5556ca4e6560f91b20af9017f4cc62127cc4447e3ce9d0257fac28710c199846
   languageName: node
   linkType: hard
 
@@ -5006,7 +4990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
+"get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
@@ -7100,13 +7084,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pngjs@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "pngjs@npm:5.0.0"
-  checksum: 10c0/c074d8a94fb75e2defa8021e85356bf7849688af7d8ce9995b7394d57cd1a777b272cfb7c4bce08b8d10e71e708e7717c81fd553a413f21840c548ec9d4893c6
-  languageName: node
-  linkType: hard
-
 "postcss-value-parser@npm:^4.0.2, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
@@ -7201,7 +7178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.10, prop-types@npm:^15.6.0, prop-types@npm:^15.7.2, prop-types@npm:^15.8.0":
+"prop-types@npm:^15.5.10, prop-types@npm:^15.6.0, prop-types@npm:^15.7.2":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -7245,19 +7222,6 @@ __metadata:
   bin:
     qrcode-terminal: ./bin/qrcode-terminal.js
   checksum: 10c0/7561a649d21d7672d451ada5f2a2b393f586627cea75670c97141dc2b4b4145db547e1fddf512a3552e7fb54de530d513a736cd604c840adb908ed03c32312ad
-  languageName: node
-  linkType: hard
-
-"qrcode@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "qrcode@npm:1.5.4"
-  dependencies:
-    dijkstrajs: "npm:^1.0.1"
-    pngjs: "npm:^5.0.0"
-    yargs: "npm:^15.3.1"
-  bin:
-    qrcode: bin/qrcode
-  checksum: 10c0/ae1d57c9cff6099639a590b432c71b15e3bd3905ce4353e6d00c95dee6bb769a8f773f6a7575ecc1b8ed476bf79c5138a4a65cb380c682de3b926d7205d34d10
   languageName: node
   linkType: hard
 
@@ -7531,21 +7495,6 @@ __metadata:
     react-native: "*"
     react-native-safe-area-context: "*"
   checksum: 10c0/8add9b730f26737422621289cc0d4be020236d190d8f5173c3dadef7ba413f2a7b7b2b173f4c33bbe2c66c8ad7d2477e412f5cf406fd948596657123684febce
-  languageName: node
-  linkType: hard
-
-"react-native-qrcode-svg@npm:^6.3.15":
-  version: 6.3.21
-  resolution: "react-native-qrcode-svg@npm:6.3.21"
-  dependencies:
-    prop-types: "npm:^15.8.0"
-    qrcode: "npm:^1.5.4"
-    text-encoding: "npm:^0.7.0"
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.63.4"
-    react-native-svg: ">=14.0.0"
-  checksum: 10c0/2d227996de5d95148146033940a8f16fd9a7f5b72f10b64da5e20738fc139d386469e850b60cb0eec9e8dc54d3cabe32fd99be18685f90f2e1fc406fb9cdd2e2
   languageName: node
   linkType: hard
 
@@ -7865,13 +7814,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-main-filename@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "require-main-filename@npm:2.0.0"
-  checksum: 10c0/db91467d9ead311b4111cbd73a4e67fa7820daed2989a32f7023785a2659008c6d119752d9c4ac011ae07e537eb86523adff99804c5fdb39cd3a017f9b401bb6
-  languageName: node
-  linkType: hard
-
 "requireg@npm:^0.2.2":
   version: 0.2.2
   resolution: "requireg@npm:0.2.2"
@@ -8070,13 +8012,6 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:~0.19.1"
   checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
-  languageName: node
-  linkType: hard
-
-"set-blocking@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "set-blocking@npm:2.0.0"
-  checksum: 10c0/9f8c1b2d800800d0b589de1477c753492de5c1548d4ade52f57f1d1f5e04af5481554d75ce5e5c43d4004b80a3eb714398d6907027dc0534177b7539119f4454
   languageName: node
   linkType: hard
 
@@ -8480,13 +8415,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"text-encoding@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "text-encoding@npm:0.7.0"
-  checksum: 10c0/6c20f5d19f996501677cc60b79bc4af550f840b426eacc5f67bd2bd5a7a7a058ab58679f851e0afee879aaaaf7fdb95cfe4de35ab29f9b34f9ce2a7b8de9bacb
-  languageName: node
-  linkType: hard
-
 "thenify-all@npm:^1.0.0":
   version: 1.6.0
   resolution: "thenify-all@npm:1.6.0"
@@ -8856,13 +8784,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-module@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "which-module@npm:2.0.1"
-  checksum: 10c0/087038e7992649eaffa6c7a4f3158d5b53b14cf5b6c1f0e043dccfacb1ba179d12f17545d5b85ebd94a42ce280a6fe65d0cbcab70f4fc6daad1dfae85e0e6a3e
-  languageName: node
-  linkType: hard
-
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -8889,17 +8810,6 @@ __metadata:
   version: 6.3.5
   resolution: "wonka@npm:6.3.5"
   checksum: 10c0/044fe5ae26c0a32b0a1603cc0ed71ede8c9febe5bb3adab4fad5e088ceee600a84a08d0deb95a72189bbaf0d510282d183b6fb7b6e9837e7a1c9b209f788dd07
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "wrap-ansi@npm:6.2.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
   languageName: node
   linkType: hard
 
@@ -9004,13 +8914,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y18n@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "y18n@npm:4.0.3"
-  checksum: 10c0/308a2efd7cc296ab2c0f3b9284fd4827be01cfeb647b3ba18230e3a416eb1bc887ac050de9f8c4fd9e7856b2e8246e05d190b53c96c5ad8d8cb56dffb6f81024
-  languageName: node
-  linkType: hard
-
 "y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
@@ -9048,16 +8951,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^18.1.2":
-  version: 18.1.3
-  resolution: "yargs-parser@npm:18.1.3"
-  dependencies:
-    camelcase: "npm:^5.0.0"
-    decamelize: "npm:^1.2.0"
-  checksum: 10c0/25df918833592a83f52e7e4f91ba7d7bfaa2b891ebf7fe901923c2ee797534f23a176913ff6ff7ebbc1cc1725a044cc6a6539fed8bfd4e13b5b16376875f9499
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^20.2.2":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
@@ -9069,25 +8962,6 @@ __metadata:
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: 10c0/f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^15.3.1":
-  version: 15.4.1
-  resolution: "yargs@npm:15.4.1"
-  dependencies:
-    cliui: "npm:^6.0.0"
-    decamelize: "npm:^1.2.0"
-    find-up: "npm:^4.1.0"
-    get-caller-file: "npm:^2.0.1"
-    require-directory: "npm:^2.1.1"
-    require-main-filename: "npm:^2.0.0"
-    set-blocking: "npm:^2.0.0"
-    string-width: "npm:^4.2.0"
-    which-module: "npm:^2.0.0"
-    y18n: "npm:^4.0.0"
-    yargs-parser: "npm:^18.1.2"
-  checksum: 10c0/f1ca680c974333a5822732825cca7e95306c5a1e7750eb7b973ce6dc4f97a6b0a8837203c8b194f461969bfe1fb1176d1d423036635285f6010b392fa498ab2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ticket-Barcodes werden vom Kollektor gesendet und von der App nur angezeigt, deshalb wurde der Code entfernt, der einen Barcode in der App generiert. Die Bibliothek 'react-native-qrcode-svg' wurde entfernt, weil diese nicht mehr benötigt wird.