### PR TITLE
Fix // ÖPNV // Barcode nicht sichtbar

### DIFF
--- a/apps/app-olea/package.json
+++ b/apps/app-olea/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.1",
     "@notifee/react-native": "^9.1.8",
-    "@olea-bps/base": "^1.0.2",
+    "@olea-bps/base": "^1.0.4",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-masked-view/masked-view": "0.3.2",
@@ -21,6 +21,7 @@
     "@react-navigation/stack": "^7.4.10",
     "accordion-collapse-react-native": "^1.1.1",
     "dayjs": "^1.11.18",
+    "expo": "~54.0.32",
     "expo-application": "~7.0.8",
     "expo-asset": "~12.0.9",
     "expo-auth-session": "~7.0.11",
@@ -34,13 +35,14 @@
     "expo-secure-store": "~15.0.7",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",
-    "expo": "~54.0.32",
     "i18next": "^25.6.0",
     "install": "^0.13.0",
     "lodash": "^4.17.21",
     "luxon": "^3.7.2",
+    "react": "19.1.4",
     "react-dom": "19.1.0",
     "react-i18next": "^16.0.1",
+    "react-native": "0.81.6",
     "react-native-big-calendar": "^4.18.6",
     "react-native-calendar-strip": "^2.2.6",
     "react-native-color-matrix-image-filters": "^7.0.2",
@@ -53,9 +55,7 @@
     "react-native-tab-view": "^4.1.3",
     "react-native-web": "^0.21.2",
     "react-native-webview": "13.16.0",
-    "react-native": "0.81.6",
-    "react-redux": "^9.2.0",
-    "react": "19.1.4"
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olea-bps/base",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OLEA base library",
   "main": "index.js",
   "repository": {

--- a/packages/views/PublicTransportTicket/index.js
+++ b/packages/views/PublicTransportTicket/index.js
@@ -12,7 +12,12 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+    useState,
+    useEffect,
+    useMemo,
+    useCallback,
+} from 'react';
 import {
     AppState,
     SafeAreaView,
@@ -20,9 +25,9 @@ import {
     ScrollView,
     StyleSheet,
     Alert,
-    useWindowDimensions,
     RefreshControl,
     Image,
+    useWindowDimensions,
 } from 'react-native';
 
 import { useTheme, Text, Button } from 'react-native-paper';
@@ -40,6 +45,7 @@ import componentStyles from './styles';
  */
 export default function PublicTransportTicketView() {
     const componentName = PublicTransportTicketView.name;
+    const { height: windowHeight } = useWindowDimensions();
     // Get theme from theme context
     const theme = useTheme();
     const { themeStyles } = theme;
@@ -48,7 +54,6 @@ export default function PublicTransportTicketView() {
 
     const [user, login] = useUser();
     const [ticketBarcode, ticketOwner, ticketValidFrom, ticketValidTo, refreshTicket] = usePublicTransportTicket();
-    const { width } = useWindowDimensions();
 
     const [refreshingTicketScrollView, setRefreshingTicketScrollView] = useState(false);
 
@@ -124,7 +129,15 @@ export default function PublicTransportTicketView() {
                                     ? <>
                                         <View>
                                             <Image
+                                                style={{
+                                                    // Der Barcode soll die Hälfte der Bildschirmhöhe ausfüllen.
+                                                    height: windowHeight / 2,
+                                                    width: '100%',
+                                                }}
                                                 source={{ uri: ticketBarcode }}
+                                                // Barcode soll auf die passende Größe angepasst und zentriert werden.
+                                                // Beim anpassen, wird das Seitenverhältnis beibehalten.
+                                                resizeMode='center'
                                             />
                                         </View>
                                         <Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,7 +2315,7 @@ __metadata:
     "@babel/core": "npm:^7.28.4"
     "@babel/runtime": "npm:^7.27.1"
     "@notifee/react-native": "npm:^9.1.8"
-    "@olea-bps/base": "npm:^1.0.2"
+    "@olea-bps/base": "npm:^1.0.4"
     "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-community/netinfo": "npm:^11.4.1"
     "@react-native-masked-view/masked-view": "npm:0.3.2"
@@ -2364,7 +2364,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@olea-bps/base@npm:^1.0.2, @olea-bps/base@workspace:packages":
+"@olea-bps/base@npm:^1.0.4, @olea-bps/base@workspace:packages":
   version: 0.0.0-use.local
   resolution: "@olea-bps/base@workspace:packages"
   dependencies:


### PR DESCRIPTION
Der Ticketbarcode wird nun größer(50% der Bildschirmhöhe) dargestellt. Vorher wurde der Barcode nicht angezeigt, weil der Image-Komponente keine Größenangaben übergeben wurde. Der Barcode wird zentriert angezeigt und auf den vorhandenen Platz angepasst, wobei das Seitenverhältnis beibehalten wird.