### PR TITLE
Bug // ÖPNV // Gültigkeitsdatum des Ticket wird im ISO 8601 Format angezeigt

### DIFF
--- a/packages/context/context-public-transport-ticket/CollektorVersion2ApiProvider.js
+++ b/packages/context/context-public-transport-ticket/CollektorVersion2ApiProvider.js
@@ -1,4 +1,8 @@
+import { DateTime } from 'luxon';
+
 import HttpApiProvider, { JsonContentType } from '../../libraries/base-api-provider';
+
+
 
 /**
  * Infos-API-Client für Kollektor
@@ -25,7 +29,24 @@ export default class CollektorVersion2ApiProvider extends HttpApiProvider {
         const getTicketUrl = this.getTicketUrl();
 
         return this.get(getTicketUrl)
-            .then(response => response.json());
+            .then(response => response.json())
+            .then(
+                jsonTicket => {
+                    const ticketValidFromDateTime = jsonTicket?.validFrom
+                        ? DateTime.fromISO(jsonTicket.validFrom)
+                        : null;
+
+                    const ticketValidToDateTime = jsonTicket?.validTo
+                        ? DateTime.fromISO(jsonTicket?.validTo)
+                        : null;
+
+                    return {
+                        ...jsonTicket,
+                        validFrom: ticketValidFromDateTime,
+                        validTo: ticketValidToDateTime,
+                    }
+                }
+            );
     }
 
     /**

--- a/packages/context/context-public-transport-ticket/index.js
+++ b/packages/context/context-public-transport-ticket/index.js
@@ -16,6 +16,8 @@ import { createContext, useEffect, useContext, useMemo, useCallback } from 'reac
 
 import { useTheme } from 'react-native-paper';
 
+import { DateTime } from 'luxon';
+
 import { useSecureStoredState } from '../../libraries/stored-state';
 import { useLanguage, useStagingServer } from '../../libraries/core';
 import { useAccessToken } from '../context-user';
@@ -34,8 +36,8 @@ import CollektorVersion2ApiProvider from './CollektorVersion2ApiProvider';
  * @typedef PublicTransportTicketContext
  * @property {string} ticketBarcode Barcode Data-URI/URL
  * @property {string} ticketOwner
- * @property {string} ticketValidFrom
- * @property {string} ticketValidTo
+ * @property {DateTime|null} ticketValidFrom
+ * @property {DateTime|null} ticketValidTo
  * @property {() => Promise<void>} refreshTicket
  */
 
@@ -137,7 +139,13 @@ function usePublicTransportTicketContext() {
  * Liefert alle noch austehenden Infos zurück.
  * Austehende Infos sind noch nicht als angezeigt markiert.
  *
- * @returns {[barcode: string|undefined, owner: string|undefined, validForm: string|undefined, validTo: string|undefined, refreshTicket: () => Promise<void>|undefined]}
+ * @returns {[
+ *     barcode: string|undefined,
+ *     owner: string|undefined,
+ *     validForm: DateTime|null,
+ *     validTo: DateTime|null,
+ *     refreshTicket: () => Promise<void>|undefined,
+ * ]}
  * @example
  * const [
  *     ticketBarcode,


### PR DESCRIPTION
Der ÖPNV-Kontext bekommt die Gültigkeitsdatums schon von dem Provider vorgeparsed, sodass das Gültig-Von-Datum und das Gültig-Bis-Datum als Luxon DateTime vorliegen.