### PR TITLE
ci: pin npm to 11 in the publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upgrade npm for OIDC support
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
           echo "npm version: $(npm --version)"
 
       # No --frozen-lockfile: unenforced for workspace deps here, and it


### PR DESCRIPTION
## Summary
`npm@latest` is now 12, which requires node >= 22. The publish workflow runs
node 20, so the OIDC upgrade step fails and the 1.1.3 publish never ran.

## Changes
- `npm install -g npm@latest` → `npm@11`

## How to verify
`npm view npm@11 engines` → `{ node: '^20.17.0 || >=22.9.0' }`

## Testing
- Not run: the publish job only fires on pushes to `main`.