### PR TITLE
Bug // ÖPNV // Absturz beim Öffnen des Deutschlandtickets

### DIFF
--- a/packages/views/PublicTransportTicket/index.js
+++ b/packages/views/PublicTransportTicket/index.js
@@ -56,10 +56,10 @@ export default function PublicTransportTicketView() {
     const [ticketBarcode, ticketOwner, ticketValidFrom, ticketValidTo, refreshTicket] = usePublicTransportTicket();
     // Gültikeitsangabem in lokaliesierte Strings umwandeln
     // Es wird immer in deutsche Datumangaben umgewandelt, weil das Deutschlandticket nur in deutschland gültig ist.
-    const localizedTicketValidFrom = ticketValidFrom?.isValid()
+    const localizedTicketValidFrom = ticketValidFrom?.isValid
         ? ticketValidFrom?.setLocale('de')?.toLocaleString()
         : null;
-    const localizedTicketValidTo = ticketValidTo?.isValid()
+    const localizedTicketValidTo = ticketValidTo?.isValid
         ? ticketValidTo?.setLocale('de')?.toLocaleString()
         : null;
 


### PR DESCRIPTION
Die isValid-Property von der Datetime-Klasse der luxon-Bibliothek wird nicht mehr als Methode gerufen.