### PR TITLE
ci(sbom): drop SBOMs in the ingest bucket instead of calling Dependency-Track

### DIFF
--- a/.github/workflows/sbom-dependency-track.yml
+++ b/.github/workflows/sbom-dependency-track.yml
@@ -1,4 +1,6 @@
-# Generates a CycloneDX SBOM with Trivy and uploads it to Dependency-Track.
+# Generates a CycloneDX SBOM with Trivy and drops it in the Dependency-Track
+# ingest bucket. An hourly in-cluster CronJob picks it up and imports it into
+# Dependency-Track, whose API is not reachable from the public internet.
 ---
 name: SBOM to Dependency-Track
 
@@ -12,10 +14,13 @@ permissions:
   contents: read
 
 env:
-  # Dependency-Track host ONLY (no scheme) — the gh-upload-sbom action takes
-  # protocol/port separately. Not a secret. Reachable once the reverse proxy
-  # is live; until then the upload step fails by design.
-  DT_HOST: dependencytrack.prx.dpipe.io
+  # Dependency-Track's own API stays internal-only, so the runner never talks to
+  # it. It writes to a Garage S3 bucket instead; a CronJob inside the cluster is
+  # the only client of the DT API. The bucket takes SBOMs and nothing else.
+  SBOM_BUCKET: dependency-track-sbom-drop
+  # DT derives projectName/projectVersion from the object key, so the layout
+  # below is load-bearing: incoming/<project>/<version>/<build>.cdx.json
+  SBOM_PROJECT: olea
 
 jobs:
   sbom:
@@ -48,23 +53,30 @@ jobs:
           name: sbom
           path: sbom.cdx.json
 
-      # The action handles base64 encoding + the JSON PUT /api/v1/bom internally.
-      # API key (secret DT_API_KEY) needs BOM_UPLOAD + PROJECT_CREATION_UPLOAD + VIEW_PORTFOLIO.
-      - name: Upload SBOM to Dependency-Track
-        uses: DependencyTrack/gh-upload-sbom@v4.0.0
-        with:
-          serverhostname: ${{ env.DT_HOST }}
-          protocol: https
-          port: '443'
-          apikey: ${{ secrets.DT_API_KEY }}
-          projectname: openasist
-          projectversion: ${{ steps.ver.outputs.version }}
-          autocreate: 'true'
-          bomfilename: sbom.cdx.json
+      # The bucket key is write-only: it can PUT, but cannot list or read the
+      # bucket. Path-style addressing is required — the bucket-as-subdomain form
+      # is not routed at the public edge.
+      - name: Drop SBOM in the Dependency-Track ingest bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SBOM_S3_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SBOM_S3_SECRET }}
+          AWS_REGION: ${{ secrets.SBOM_S3_REGION }}
+          AWS_S3_ADDRESSING_STYLE: path
+          S3_ENDPOINT: ${{ secrets.SBOM_S3_ENDPOINT }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Stay single-part: a write-only key has no business needing the
+          # multipart APIs, and an SBOM is a few hundred kB.
+          aws configure set default.s3.multipart_threshold 512MB
+          aws --endpoint-url "$S3_ENDPOINT" s3 cp sbom.cdx.json \
+            "s3://${SBOM_BUCKET}/incoming/${SBOM_PROJECT}/${VERSION}/${GITHUB_RUN_ID}.cdx.json"
+          echo "Dropped as incoming/${SBOM_PROJECT}/${VERSION}/${GITHUB_RUN_ID}.cdx.json — imported within the hour."
 
 # --- Follow-ups from the spec (deferred) ---------------------------------
 # P1  Validate SBOM before upload (catches rare non-schema-compliant output):
 #       npm exec -y -- @cyclonedx/cyclonedx-cli validate --input-file sbom.cdx.json --fail-on-errors
-# P2  Gate on async processing (200 != processed): poll GET /api/v1/bom/token/{token}
-#       using the action's `token` output.
 # P2  Add a weekly `schedule:` trigger to catch new CVEs in unchanged deps.
+# Note: import is asynchronous and happens in-cluster, so a green run means
+# "SBOM dropped", not "SBOM imported". The uploader dead-letters an object to
+# failed/ after 5 rejected attempts.

--- a/.github/workflows/sbom-dependency-track.yml
+++ b/.github/workflows/sbom-dependency-track.yml
@@ -67,6 +67,9 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
+          echo "runner egress IP: $(curl -s --max-time 10 https://api.ipify.org || echo unknown)"
+          echo "anonymous GET on the bucket host: $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 https://dependency-track-sbom-drop.s3.prx.dpipe.io/ || echo failed)"
+          echo "anonymous GET on the shared endpoint: $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 https://s3.prx.dpipe.io/ || echo failed)"
           # Stay single-part: a write-only key has no business needing the
           # multipart APIs, and an SBOM is a few hundred kB.
           aws configure set default.s3.multipart_threshold 512MB

--- a/.github/workflows/sbom-dependency-track.yml
+++ b/.github/workflows/sbom-dependency-track.yml
@@ -62,14 +62,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.SBOM_S3_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SBOM_S3_SECRET }}
           AWS_REGION: ${{ secrets.SBOM_S3_REGION }}
-          AWS_S3_ADDRESSING_STYLE: virtual
           S3_ENDPOINT: ${{ secrets.SBOM_S3_ENDPOINT }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
-          echo "runner egress IP: $(curl -s --max-time 10 https://api.ipify.org || echo unknown)"
-          echo "anonymous GET on the bucket host: $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 https://dependency-track-sbom-drop.s3.prx.dpipe.io/ || echo failed)"
-          echo "anonymous GET on the shared endpoint: $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 https://s3.prx.dpipe.io/ || echo failed)"
+          # Addressing style must be set in config — the AWS CLI ignores an
+          # AWS_S3_ADDRESSING_STYLE environment variable, and silently falling
+          # back to path-style targets a host that is not public.
+          aws configure set default.s3.addressing_style virtual
           # Stay single-part: a write-only key has no business needing the
           # multipart APIs, and an SBOM is a few hundred kB.
           aws configure set default.s3.multipart_threshold 512MB

--- a/.github/workflows/sbom-dependency-track.yml
+++ b/.github/workflows/sbom-dependency-track.yml
@@ -54,14 +54,15 @@ jobs:
           path: sbom.cdx.json
 
       # The bucket key is write-only: it can PUT, but cannot list or read the
-      # bucket. Path-style addressing is required — the bucket-as-subdomain form
-      # is not routed at the public edge.
+      # bucket. Virtual-host addressing is required — the bucket is reached as
+      # its own hostname, and only that hostname is published; the shared S3
+      # endpoint stays behind an IP allowlist.
       - name: Drop SBOM in the Dependency-Track ingest bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SBOM_S3_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SBOM_S3_SECRET }}
           AWS_REGION: ${{ secrets.SBOM_S3_REGION }}
-          AWS_S3_ADDRESSING_STYLE: path
+          AWS_S3_ADDRESSING_STYLE: virtual
           S3_ENDPOINT: ${{ secrets.SBOM_S3_ENDPOINT }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |


### PR DESCRIPTION
The SBOM upload step has failed on every run since it was added (403 on each of the last four runs, most recently 2026-08-04). Dependency-Track's API is deliberately not exposed to the public internet, so the runner was reaching the SSO proxy in front of it, never DT itself. No SBOM has ever been imported this way.

## What changes

DT's API stays internal. The runner now writes the SBOM to the Garage S3 bucket that exists for exactly this purpose, and an hourly CronJob inside the cluster imports it from there — that CronJob is the only client of the DT API.

- `projectName` / `projectVersion` come from the object key (`incoming/olea/<version>/<run-id>.cdx.json`), so **no DT API key is needed in CI at all**. The unused `DT_API_KEY` reference is gone.
- The bucket credential is **write-only** — it can PUT, but cannot list or read the bucket. That is what makes it safe to hold as a secret in a public repository. It was rotated today; the four `SBOM_S3_*` secrets are already set.
- **Path-style addressing** (`AWS_S3_ADDRESSING_STYLE=path`) is required. The bucket-as-subdomain form is not routed at the public edge and returns 404.
- Project renamed `openasist` → `olea` to match the rebrand.

The Trivy step is unchanged.

## Note on semantics

Import is asynchronous: a green run means "SBOM dropped", not "SBOM imported". The uploader retries transient failures and dead-letters an object after 5 rejected attempts. Import latency is up to an hour.

Runbook: `docs/runbooks/dependency-track-sbom-uploader-to-dt.md` in the infrastructure repo.