### PR TITLE
chore: bump @olea-bps/base to 1.1.4

### DIFF
--- a/apps/app-olea/package.json
+++ b/apps/app-olea/package.json
@@ -12,7 +12,7 @@
     "@babel/runtime": "^7.27.1",
     "@expo/vector-icons": "^15.0.2",
     "@notifee/react-native": "^9.1.8",
-    "@olea-bps/base": "^1.1.3",
+    "@olea-bps/base": "^1.1.4",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",
     "@react-native-masked-view/masked-view": "0.3.2",

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olea-bps/base",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "OLEA base library",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

Bumps the `@olea-bps/base` workspace package to 1.1.4 and updates the
consumer range in `app-olea` to match. No `yarn.lock` change needed —
workspace packages aren't recorded in the lockfile.